### PR TITLE
Add `enabled` flag for Flow Log. Add S3 bucket policy. Pin providers for TF 0.14. Update example

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,3 +12,6 @@
 
 # Cloud Posse must review any changes to GitHub actions
 .github/*     @cloudposse/engineering
+
+# Cloud Posse must review any changes to standard context definition
+**/context.tf   @cloudposse/engineering

--- a/.github/auto-release.yml
+++ b/.github/auto-release.yml
@@ -1,0 +1,40 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: '$RESOLVED_VERSION'
+version-template: '$MAJOR.$MINOR.$PATCH'
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+      - 'enhancement'
+  patch:
+    labels:
+      - 'patch'
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+      - 'hotfix'
+  default: 'minor'
+
+categories:
+  - title: '🚀 Enhancements'
+    labels:
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+      - 'hotfix'
+
+change-template: |
+  <details>
+    <summary>$TITLE @$AUTHOR (#$NUMBER)</summary>
+
+    $BODY
+  </details>
+
+template: |
+  $CHANGES

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,19 @@
+name: auto-release
+
+on:
+  push:
+    branches:
+    - master
+
+jobs:
+  semver:
+    runs-on: ubuntu-latest
+    steps:
+    # Drafts your next Release notes as Pull Requests are merged into "master"
+    - uses: release-drafter/release-drafter@v5
+      with:
+        publish: true
+        prerelease: false
+        config-name: auto-release.yml
+      env:
+        GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}

--- a/.github/workflows/chatops.yml
+++ b/.github/workflows/chatops.yml
@@ -9,13 +9,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: "Handle common commands"
-        uses: cloudposse/actions/github/slash-command-dispatch@0.15.0
+        uses: cloudposse/actions/github/slash-command-dispatch@0.16.0
         with:
           token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
           reaction-token: ${{ secrets.GITHUB_TOKEN }}
           repository: cloudposse/actions
           commands: rebuild-readme, terraform-fmt
-          permission: none
+          permission: triage
           issue-type: pull-request
 
   test:
@@ -24,13 +24,13 @@ jobs:
       - name: "Checkout commit"
         uses: actions/checkout@v2
       - name: "Run tests"
-        uses: cloudposse/actions/github/slash-command-dispatch@0.15.0
+        uses: cloudposse/actions/github/slash-command-dispatch@0.16.0
         with:
           token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
           reaction-token: ${{ secrets.GITHUB_TOKEN }}
           repository: cloudposse/actions
           commands: test
-          permission: none
+          permission: triage
           issue-type: pull-request
           reactions: false
 

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2017-2019 Cloud Posse, LLC
+   Copyright 2017-2020 Cloud Posse, LLC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -77,9 +77,17 @@ The module will create:
 Instead pin to the release tag (e.g. `?ref=tags/x.y.z`) of one of our [latest releases](https://github.com/cloudposse/terraform-aws-vpc-flow-logs-s3-bucket/releases).
 
 
+For a complete example, see [examples/complete](examples/complete).
+
+For automated tests of the complete example using [bats](https://github.com/bats-core/bats-core) and [Terratest](https://github.com/gruntwork-io/terratest)
+(which tests and deploys the example on Datadog), see [test](test).
+
+
 ```hcl
   module "vpc" {
-    source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=master"
+    source  = "cloudposse/vpc/aws"
+    version = "0.18.0"
+
     namespace  = "eg"
     stage      = "test"
     name       = "flowlogs"
@@ -87,7 +95,8 @@ Instead pin to the release tag (e.g. `?ref=tags/x.y.z`) of one of our [latest re
   }
 
   module "flow_logs" {
-    source = "git::https://github.com/cloudposse/terraform-aws-vpc-flow-logs-s3-bucket.git?ref=master"
+    source  = "cloudposse/vpc-flow-logs-s3-bucket/aws"
+    version = "0.8.0"
 
     namespace  = "eg"
     stage      = "test"
@@ -120,7 +129,7 @@ Available targets:
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.0 |
-| http | >= 2.0 |
+| aws | >= 2.0 |
 | local | >= 1.3 |
 | template | >= 2.2 |
 
@@ -128,7 +137,7 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | >= 2.0 |
 
 ## Inputs
 

--- a/README.yaml
+++ b/README.yaml
@@ -10,8 +10,10 @@ name: terraform-aws-vpc-flow-logs-s3-bucket
 
 # License of this project
 license: "APACHE2"
+
 # Canonical GitHub repo
 github_repo: cloudposse/terraform-aws-vpc-flow-logs-s3-bucket
+
 # Badges to display
 badges:
   - name: "Latest Release"
@@ -20,6 +22,7 @@ badges:
   - name: "Slack Community"
     image: "https://slack.cloudposse.com/badge.svg"
     url: "https://slack.cloudposse.com"
+
 related:
   - name: "terraform-aws-vpc"
     description: "Terraform Module that defines a VPC with public/private subnets across multiple AZs with Internet Gateways"
@@ -27,23 +30,26 @@ related:
   - name: "CIS AWS Foundations Benchmark in the AWS Cloud"
     description: "CIS Benchmarks are consensus-based configuration guidelines developed by experts in US government, business, industry, and academia to help organizations assess and improve security"
     url: "https://github.com/aws-quickstart/quickstart-compliance-cis-benchmark"
+
 # Short description of this project
 description: |-
   Terraform module to create AWS [`VPC Flow logs`](https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs.html) backed by S3.
+
 introduction: |-
   The module will create:
 
-  * KMS key
-  * S3 bucket with server side encryption by the key
-  * VPC flow logs backed by the S3 bucket
+  * S3 bucket with server side encryption
+  * KMS key to encrypt flow logs files in the bucket
+  * Optional VPC Flow Log backed by the S3 bucket (this can be disabled, e.g. in multi-account environments if you want to create an S3 bucket in one account and VPC Flow Logs in different accounts)
+
 # How to use this project
 usage: |-
   ```hcl
     module "vpc" {
       source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=master"
       namespace  = "eg"
-      stage      = "prod"
-      name       = "flow"
+      stage      = "test"
+      name       = "flowlogs"
       cidr_block = "172.16.0.0/16"
     }
 
@@ -51,16 +57,17 @@ usage: |-
       source = "git::https://github.com/cloudposse/terraform-aws-vpc-flow-logs-s3-bucket.git?ref=master"
 
       namespace  = "eg"
-      stage      = "prod"
-      name       = "flow"
+      stage      = "test"
+      name       = "flowlogs"
 
-      region = "us-west-2"
       vpc_id = module.vpc.vpc_id
     }
   ```
+
 include:
   - "docs/targets.md"
   - "docs/terraform.md"
+
 # Contributors to this project
 contributors:
   - name: "Igor Rodionov"

--- a/README.yaml
+++ b/README.yaml
@@ -44,9 +44,17 @@ introduction: |-
 
 # How to use this project
 usage: |-
+  For a complete example, see [examples/complete](examples/complete).
+
+  For automated tests of the complete example using [bats](https://github.com/bats-core/bats-core) and [Terratest](https://github.com/gruntwork-io/terratest)
+  (which tests and deploys the example on Datadog), see [test](test).
+
+
   ```hcl
     module "vpc" {
-      source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=master"
+      source  = "cloudposse/vpc/aws"
+      version = "0.18.0"
+
       namespace  = "eg"
       stage      = "test"
       name       = "flowlogs"
@@ -54,7 +62,8 @@ usage: |-
     }
 
     module "flow_logs" {
-      source = "git::https://github.com/cloudposse/terraform-aws-vpc-flow-logs-s3-bucket.git?ref=master"
+      source  = "cloudposse/vpc-flow-logs-s3-bucket/aws"
+      version = "0.8.0"
 
       namespace  = "eg"
       stage      = "test"

--- a/context.tf
+++ b/context.tf
@@ -19,7 +19,8 @@
 #
 
 module "this" {
-  source = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.19.2"
+  source  = "cloudposse/label/null"
+  version = "0.22.0"
 
   enabled             = var.enabled
   namespace           = var.namespace

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -4,7 +4,7 @@
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.0 |
-| http | >= 2.0 |
+| aws | >= 2.0 |
 | local | >= 1.3 |
 | template | >= 2.2 |
 
@@ -12,7 +12,7 @@
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | >= 2.0 |
 
 ## Inputs
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -4,27 +4,29 @@
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.0 |
-| aws | >= 2.0 |
+| http | >= 2.0 |
 | local | >= 1.3 |
-| template | >= 2.0 |
+| template | >= 2.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.0 |
+| aws | n/a |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | additional\_tag\_map | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
+| arn\_format | ARN format to be used. May be changed to support deployment in GovCloud/China regions | `string` | `"arn:aws"` | no |
 | attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
 | context | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | <pre>object({<br>    enabled             = bool<br>    namespace           = string<br>    environment         = string<br>    stage               = string<br>    name                = string<br>    delimiter           = string<br>    attributes          = list(string)<br>    tags                = map(string)<br>    additional_tag_map  = map(string)<br>    regex_replace_chars = string<br>    label_order         = list(string)<br>    id_length_limit     = number<br>  })</pre> | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_order": [],<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
 | delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
 | enabled | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | environment | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | expiration\_days | Number of days after which to expunge the objects | `number` | `90` | no |
+| flow\_log\_enabled | Enable/disable the Flow Log creation. Useful in multi-account environments where the bucket is in one account, but VPC Flow Logs are in different accounts | `bool` | `true` | no |
 | force\_destroy | A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable | `bool` | `false` | no |
 | glacier\_transition\_days | Number of days after which to move the data to the glacier storage tier | `number` | `60` | no |
 | id\_length\_limit | Limit `id` to this many characters.<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
@@ -37,7 +39,6 @@
 | noncurrent\_version\_expiration\_days | Specifies when noncurrent object versions expire | `number` | `90` | no |
 | noncurrent\_version\_transition\_days | Specifies when noncurrent object versions transitions | `number` | `30` | no |
 | regex\_replace\_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
-| region | If specified, the AWS region this bucket should reside in. Otherwise, the region used by the callee | `string` | `""` | no |
 | stage | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | standard\_transition\_days | Number of days to persist in the standard storage tier before moving to the infrequent access tier | `number` | `30` | no |
 | tags | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
@@ -52,7 +53,8 @@
 | bucket\_domain\_name | FQDN of bucket |
 | bucket\_id | Bucket Name (aka ID) |
 | bucket\_prefix | Bucket prefix configured for lifecycle rules |
-| id | The Flow Log ID |
+| flow\_log\_arn | Flow Log ARN |
+| flow\_log\_id | Flow Log ID |
 | kms\_alias\_arn | KMS Alias ARN |
 | kms\_alias\_name | KMS Alias name |
 | kms\_key\_arn | KMS Key ARN |

--- a/examples/complete/context.tf
+++ b/examples/complete/context.tf
@@ -19,7 +19,8 @@
 #
 
 module "this" {
-  source = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.19.2"
+  source  = "cloudposse/label/null"
+  version = "0.22.0"
 
   enabled             = var.enabled
   namespace           = var.namespace

--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -1,5 +1,7 @@
 region = "us-east-2"
 
-namespace = "example"
-stage     = "development"
-name      = "flowlogs"
+namespace = "eg"
+
+stage = "test"
+
+name = "flowlogs"

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -3,22 +3,31 @@ provider "aws" {
 }
 
 module "vpc" {
-  // https://github.com/cloudposse/terraform-aws-vpc
-  source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=0.17.0"
-  enabled    = module.this.enabled
-  namespace  = module.this.namespace
-  stage      = module.this.stage
-  name       = module.this.name
+  source  = "cloudposse/vpc/aws"
+  version = "0.18.0"
+
   cidr_block = "172.16.0.0/16"
+
+  context = module.this.context
 }
 
 module "flow_logs" {
   source = "../../"
 
-  context = module.this.context
-  region  = var.region
-  vpc_id  = module.vpc.vpc_id
+  arn_format                         = var.arn_format
+  flow_log_enabled                   = var.flow_log_enabled
+  lifecycle_prefix                   = var.lifecycle_prefix
+  lifecycle_rule_enabled             = var.lifecycle_rule_enabled
+  noncurrent_version_expiration_days = var.noncurrent_version_expiration_days
+  noncurrent_version_transition_days = var.noncurrent_version_transition_days
+  standard_transition_days           = var.standard_transition_days
+  glacier_transition_days            = var.glacier_transition_days
+  expiration_days                    = var.expiration_days
+  traffic_type                       = var.traffic_type
+  vpc_id                             = module.vpc.vpc_id
 
   // For testing
   force_destroy = true
+
+  context = module.this.context
 }

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -1,15 +1,49 @@
-output "bucket_arn" {
-  value = module.flow_logs.bucket_arn
+output "kms_key_arn" {
+  value       = module.flow_logs.kms_key_arn
+  description = "KMS Key ARN"
+}
+
+output "kms_key_id" {
+  value       = module.flow_logs.kms_key_id
+  description = "KMS Key ID"
+}
+
+output "kms_alias_arn" {
+  value       = module.flow_logs.kms_alias_arn
+  description = "KMS Alias ARN"
+}
+
+output "kms_alias_name" {
+  value       = module.flow_logs.kms_alias_name
+  description = "KMS Alias name"
 }
 
 output "bucket_domain_name" {
-  value = module.flow_logs.bucket_domain_name
+  value       = module.flow_logs.bucket_domain_name
+  description = "FQDN of bucket"
+}
+
+output "bucket_id" {
+  value       = module.flow_logs.bucket_id
+  description = "Bucket Name (aka ID)"
+}
+
+output "bucket_arn" {
+  value       = module.flow_logs.bucket_arn
+  description = "Bucket ARN"
 }
 
 output "bucket_prefix" {
-  value = module.flow_logs.bucket_prefix
+  value       = module.flow_logs.bucket_prefix
+  description = "Bucket prefix configured for lifecycle rules"
 }
 
-output "id" {
-  value = module.flow_logs.id
+output "flow_log_id" {
+  value       = module.flow_logs.flow_log_id
+  description = "Flow Log ID"
+}
+
+output "flow_log_arn" {
+  value       = module.flow_logs.flow_log_arn
+  description = "Flow Log ARN"
 }

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -1,3 +1,70 @@
 variable "region" {
-  type = string
+  type        = string
+  description = "AWS Region"
+}
+
+variable "lifecycle_prefix" {
+  type        = string
+  description = "Prefix filter. Used to manage object lifecycle events"
+  default     = ""
+}
+
+variable "lifecycle_tags" {
+  type        = map(string)
+  description = "Tags filter. Used to manage object lifecycle events"
+  default     = {}
+}
+
+variable "lifecycle_rule_enabled" {
+  type        = bool
+  description = "Enable lifecycle events on this bucket"
+  default     = true
+}
+
+variable "noncurrent_version_expiration_days" {
+  type        = number
+  description = "Specifies when noncurrent object versions expire"
+  default     = 90
+}
+
+variable "noncurrent_version_transition_days" {
+  type        = number
+  description = "Specifies when noncurrent object versions transitions"
+  default     = 30
+}
+
+variable "standard_transition_days" {
+  type        = number
+  description = "Number of days to persist in the standard storage tier before moving to the infrequent access tier"
+  default     = 30
+}
+
+variable "glacier_transition_days" {
+  type        = number
+  description = "Number of days after which to move the data to the glacier storage tier"
+  default     = 60
+}
+
+variable "expiration_days" {
+  type        = number
+  description = "Number of days after which to expunge the objects"
+  default     = 90
+}
+
+variable "traffic_type" {
+  type        = string
+  description = "The type of traffic to capture. Valid values: `ACCEPT`, `REJECT`, `ALL`"
+  default     = "ALL"
+}
+
+variable "arn_format" {
+  type        = string
+  default     = "arn:aws"
+  description = "ARN format to be used. May be changed to support deployment in GovCloud/China regions"
+}
+
+variable "flow_log_enabled" {
+  type        = bool
+  default     = true
+  description = "Enable/disable the Flow Log creation. Useful in multi-account environments where the bucket is in one account, but VPC Flow Logs are in different accounts"
 }

--- a/main.tf
+++ b/main.tf
@@ -1,15 +1,10 @@
-module "label" {
-  source  = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.19.2"
-  context = module.this.context
-}
-
 data "aws_caller_identity" "current" {}
 
 data "aws_iam_policy_document" "kms" {
-  count = module.this.enabled == true ? 1 : 0
+  count = module.this.enabled ? 1 : 0
 
   statement {
-    sid    = "Enable IAM User Permissions"
+    sid    = "Enable Root User Permissions"
     effect = "Allow"
 
     actions = [
@@ -68,26 +63,73 @@ data "aws_iam_policy_document" "kms" {
   }
 }
 
-module "kms_key" {
-  source  = "git::https://github.com/cloudposse/terraform-aws-kms-key.git?ref=tags/0.7.0"
-  context = module.this.context
+# https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs-s3.html
+data "aws_iam_policy_document" "bucket" {
+  count = module.this.enabled ? 1 : 0
 
-  description             = "KMS key for VPC flow logs"
-  deletion_window_in_days = 10
-  enable_key_rotation     = true
+  statement {
+    sid = "AWSLogDeliveryWrite"
 
-  policy = join("", data.aws_iam_policy_document.kms.*.json)
+    principals {
+      type        = "Service"
+      identifiers = ["delivery.logs.amazonaws.com"]
+    }
+
+    actions = [
+      "s3:PutObject"
+    ]
+
+    resources = [
+      "${var.arn_format}:s3:::${module.this.id}/*"
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "s3:x-amz-acl"
+
+      values = [
+        "bucket-owner-full-control"
+      ]
+    }
+  }
+
+  statement {
+    sid = "AWSLogDeliveryAclCheck"
+
+    principals {
+      type        = "Service"
+      identifiers = ["delivery.logs.amazonaws.com"]
+    }
+
+    actions = [
+      "s3:GetBucketAcl"
+    ]
+
+    resources = [
+      "${var.arn_format}:s3:::${module.this.id}"
+    ]
+  }
 }
 
-module "s3_bucket" {
-  source  = "git::https://github.com/cloudposse/terraform-aws-s3-log-storage.git?ref=tags/0.14.0"
+module "kms_key" {
+  source  = "cloudposse/kms-key/aws"
+  version = "0.7.0"
+
+  description             = "KMS key for VPC Flow Logs"
+  deletion_window_in_days = 10
+  enable_key_rotation     = true
+  policy                  = join("", data.aws_iam_policy_document.kms.*.json)
+
   context = module.this.context
+}
 
-  kms_master_key_arn = module.kms_key.alias_arn
-  sse_algorithm      = "aws:kms"
+module "s3_log_storage_bucket" {
+  source  = "cloudposse/s3-log-storage/aws"
+  version = "0.15.0"
 
-  versioning_enabled = false
-
+  kms_master_key_arn                 = module.kms_key.alias_arn
+  sse_algorithm                      = "aws:kms"
+  versioning_enabled                 = false
   expiration_days                    = var.expiration_days
   glacier_transition_days            = var.glacier_transition_days
   lifecycle_prefix                   = var.lifecycle_prefix
@@ -96,13 +138,15 @@ module "s3_bucket" {
   noncurrent_version_expiration_days = var.noncurrent_version_expiration_days
   noncurrent_version_transition_days = var.noncurrent_version_transition_days
   standard_transition_days           = var.standard_transition_days
+  force_destroy                      = var.force_destroy
+  policy                             = join("", data.aws_iam_policy_document.bucket.*.json)
 
-  force_destroy = var.force_destroy
+  context = module.this.context
 }
 
 resource "aws_flow_log" "default" {
-  count                = module.this.enabled == true ? 1 : 0
-  log_destination      = module.s3_bucket.bucket_arn
+  count                = module.this.enabled && var.flow_log_enabled ? 1 : 0
+  log_destination      = module.s3_log_storage_bucket.bucket_arn
   log_destination_type = "s3"
   traffic_type         = var.traffic_type
   vpc_id               = var.vpc_id

--- a/outputs.tf
+++ b/outputs.tf
@@ -19,26 +19,31 @@ output "kms_alias_name" {
 }
 
 output "bucket_domain_name" {
-  value       = module.s3_bucket.bucket_domain_name
+  value       = module.s3_log_storage_bucket.bucket_domain_name
   description = "FQDN of bucket"
 }
 
 output "bucket_id" {
-  value       = module.s3_bucket.bucket_id
+  value       = module.s3_log_storage_bucket.bucket_id
   description = "Bucket Name (aka ID)"
 }
 
 output "bucket_arn" {
-  value       = module.s3_bucket.bucket_arn
+  value       = module.s3_log_storage_bucket.bucket_arn
   description = "Bucket ARN"
 }
 
 output "bucket_prefix" {
-  value       = module.s3_bucket.prefix
+  value       = module.s3_log_storage_bucket.prefix
   description = "Bucket prefix configured for lifecycle rules"
 }
 
-output "id" {
+output "flow_log_id" {
   value       = join("", aws_flow_log.default.*.id)
-  description = "The Flow Log ID"
+  description = "Flow Log ID"
+}
+
+output "flow_log_arn" {
+  value       = join("", aws_flow_log.default.*.arn)
+  description = "Flow Log ARN"
 }

--- a/test/src/Makefile
+++ b/test/src/Makefile
@@ -1,28 +1,11 @@
-PACKAGE  = terraform-aws-vpc-flow-logs-s3-bucket
-GOEXE   ?= /usr/bin/go
-GOPATH   = $(CURDIR)/.gopath
-GOBIN    = $(GOPATH)/bin
-BASE     = $(GOPATH)/src/$(PACKAGE)
-PATH 	:= $(PATH):$(GOBIN)
-
-export TF_DATA_DIR ?= $(CURDIR)/.terraform
 export TF_CLI_ARGS_init ?= -get-plugins=true
-export GOPATH
+export TERRAFORM_VERSION ?= $(shell curl -s https://checkpoint-api.hashicorp.com/v1/check/terraform | jq -r -M '.current_version' | cut -d. -f1-2)
+
+.DEFAULT_GOAL : all
 
 .PHONY: all
 ## Default target
 all: test
-
-ifneq (,$(wildcard /sbin/apk))
-## Install go, if not installed
-$(GOEXE):
-	apk add --update go
-endif
-
-## Prepare the GOPATH
-$(BASE): $(GOEXE)
-	@mkdir -p $(dir $@)
-	@ln -sf $(CURDIR) $@
 
 .PHONY : init
 ## Initialize tests
@@ -33,7 +16,7 @@ init:
 ## Run tests
 test: init
 	go mod download
-	go test -v -timeout 30m -run TestExamplesComplete
+	go test -v -timeout 60m -run TestExamplesComplete
 
 ## Run tests in docker container
 docker/test:
@@ -41,8 +24,7 @@ docker/test:
 		-e PATH="/usr/local/terraform/$(TERRAFORM_VERSION)/bin:/go/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
 		-v $(CURDIR)/../../:/module/ cloudposse/test-harness:latest -C /module/test/src test
 
-
 .PHONY : clean
 ## Clean up files
 clean:
-	rm -rf .gopath $(TF_DATA_DIR) ../../examples/complete/*.tfstate*
+	rm -rf ../../examples/complete/*.tfstate*

--- a/test/src/examples_complete_test.go
+++ b/test/src/examples_complete_test.go
@@ -28,7 +28,6 @@ func TestExamplesComplete(t *testing.T) {
 		VarFiles: []string{"fixtures.us-east-2.tfvars"},
 		Vars: map[string]interface{}{
 			"attributes": attributes,
-			"region": "us-east-2",
 		},
 	}
 
@@ -40,9 +39,12 @@ func TestExamplesComplete(t *testing.T) {
 
 	// Assume '-' delimiter
 	bucketArn := terraform.Output(t, terraformOptions, "bucket_arn")
-	bucketArnRegexp := fmt.Sprintf("arn:aws:s3:::%s-%s-%s-[0-9]{5}", "example", "development", "flowlogs")
-
+	bucketArnRegexp := fmt.Sprintf("arn:aws:s3:::%s-%s-%s-[0-9]{5}", "eg", "test", "flowlogs")
 	assert.Regexp(t, regexp.MustCompile(bucketArnRegexp), bucketArn)
-	//assert.Equal(t, bucketArn, bucketArnRegexp)
-	assert.Empty(t, terraform.Output(t, terraformOptions, "bucket_prefix"))
+
+	flowLogId := terraform.Output(t, terraformOptions, "flow_log_id")
+	assert.NotEmpty(t, flowLogId)
+
+	flowLogArn := terraform.Output(t, terraformOptions, "flow_log_arn")
+	assert.Contains(t, flowLogArn, flowLogId)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -15,12 +15,6 @@ variable "lifecycle_tags" {
   default     = {}
 }
 
-variable "region" {
-  type        = string
-  description = "If specified, the AWS region this bucket should reside in. Otherwise, the region used by the callee"
-  default     = ""
-}
-
 variable "force_destroy" {
   type        = bool
   description = "A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable"
@@ -67,4 +61,16 @@ variable "traffic_type" {
   type        = string
   description = "The type of traffic to capture. Valid values: `ACCEPT`, `REJECT`, `ALL`"
   default     = "ALL"
+}
+
+variable "arn_format" {
+  type        = string
+  default     = "arn:aws"
+  description = "ARN format to be used. May be changed to support deployment in GovCloud/China regions"
+}
+
+variable "flow_log_enabled" {
+  type        = bool
+  default     = true
+  description = "Enable/disable the Flow Log creation. Useful in multi-account environments where the bucket is in one account, but VPC Flow Logs are in different accounts"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -2,8 +2,17 @@ terraform {
   required_version = ">= 0.12.0"
 
   required_providers {
-    aws      = ">= 2.0"
-    template = ">= 2.0"
-    local    = ">= 1.3"
+    local = {
+      source  = "hashicorp/local"
+      version = ">= 1.3"
+    }
+    template = {
+      source  = "hashicorp/template"
+      version = ">= 2.2"
+    }
+    http = {
+      source  = "hashicorp/http"
+      version = ">= 2.0"
+    }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -10,8 +10,8 @@ terraform {
       source  = "hashicorp/template"
       version = ">= 2.2"
     }
-    http = {
-      source  = "hashicorp/http"
+    aws = {
+      source  = "hashicorp/aws"
       version = ">= 2.0"
     }
   }


### PR DESCRIPTION
## what
* Add `enabled` flag for Flow Log
* Add S3 bucket policy
* Pin providers for TF 0.14
* Update example

## why
* Add `enabled` flag for Flow Log: enable/disable the Flow Log creation. Useful in multi-account environments where the bucket is in one account, but VPC Flow Logs are in different accounts
* Add S3 bucket policy - was missing


