### PR TITLE
Make `vpc_id` optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Available targets:
 | standard\_transition\_days | Number of days to persist in the standard storage tier before moving to the infrequent access tier | `number` | `30` | no |
 | tags | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
 | traffic\_type | The type of traffic to capture. Valid values: `ACCEPT`, `REJECT`, `ALL` | `string` | `"ALL"` | no |
-| vpc\_id | VPC ID to create flow logs for | `string` | n/a | yes |
+| vpc\_id | VPC ID to create flow logs for | `string` | `null` | no |
 
 ## Outputs
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -43,7 +43,7 @@
 | standard\_transition\_days | Number of days to persist in the standard storage tier before moving to the infrequent access tier | `number` | `30` | no |
 | tags | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
 | traffic\_type | The type of traffic to capture. Valid values: `ACCEPT`, `REJECT`, `ALL` | `string` | `"ALL"` | no |
-| vpc\_id | VPC ID to create flow logs for | `string` | n/a | yes |
+| vpc\_id | VPC ID to create flow logs for | `string` | `null` | no |
 
 ## Outputs
 

--- a/test/src/examples_complete_test.go
+++ b/test/src/examples_complete_test.go
@@ -1,11 +1,9 @@
 package test
 
 import (
-	"fmt"
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/stretchr/testify/assert"
 	"math/rand"
-	"regexp"
 	"strconv"
 	"testing"
 	"time"
@@ -39,8 +37,7 @@ func TestExamplesComplete(t *testing.T) {
 
 	// Assume '-' delimiter
 	bucketArn := terraform.Output(t, terraformOptions, "bucket_arn")
-	bucketArnRegexp := fmt.Sprintf("arn:aws:s3:::%s-%s-%s-[0-9]{5}", "eg", "test", "flowlogs")
-	assert.Regexp(t, regexp.MustCompile(bucketArnRegexp), bucketArn)
+	assert.Equal(t, "arn:aws:s3:::eg-test-flowlogs-"+randId, bucketArn)
 
 	flowLogId := terraform.Output(t, terraformOptions, "flow_log_id")
 	assert.NotEmpty(t, flowLogId)

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,7 @@
 variable "vpc_id" {
   type        = string
   description = "VPC ID to create flow logs for"
+  default     = null
 }
 
 variable "lifecycle_prefix" {


### PR DESCRIPTION
## what
* Make `vpc_id` optional

## why
* Since we have a boolean flag to enable/disable the creation of Flow Log, if that flag is set to `false`, we don't need to provide a VPC ID

