### PR TITLE
Bump version of kms-key as it won't work on latest terraform (v0.14.25) version

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -113,7 +113,7 @@ data "aws_iam_policy_document" "bucket" {
 
 module "kms_key" {
   source  = "cloudposse/kms-key/aws"
-  version = "0.7.0"
+  version = "0.9.0"
 
   description             = "KMS key for VPC Flow Logs"
   deletion_window_in_days = 10


### PR DESCRIPTION
## what
Bump version of kms-key used by the module for KMS key creation

## why
Latest tag has older version of KMS that does not work on Terraform v0.14 (recent versions)

```
versions.tf line 2, in terraform:
   2:   required_version = ">= 0.12.0, < 0.14.0"

```
## references
null
