### PR TITLE
add arn format to the kms policy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -32,7 +32,7 @@ data "aws_iam_policy_document" "kms" {
       type = "AWS"
 
       identifiers = [
-        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+        "arn:${var.arn_format}::${data.aws_caller_identity.current.account_id}:root"
       ]
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -32,7 +32,7 @@ data "aws_iam_policy_document" "kms" {
       type = "AWS"
 
       identifiers = [
-        "${var.arn_format}::${data.aws_caller_identity.current.account_id}:root"
+        "${var.arn_format}:iam::${data.aws_caller_identity.current.account_id}:root"
       ]
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -32,7 +32,7 @@ data "aws_iam_policy_document" "kms" {
       type = "AWS"
 
       identifiers = [
-        "arn:${var.arn_format}::${data.aws_caller_identity.current.account_id}:root"
+        "${var.arn_format}::${data.aws_caller_identity.current.account_id}:root"
       ]
     }
   }


### PR DESCRIPTION
currently getting:

Error: MalformedPolicyDocumentException: Policy contains a statement with one or more invalid principals.

  on .terraform/modules/flow_logs.kms_key/main.tf line 1, in resource "aws_kms_key" "default":
   1: resource "aws_kms_key" "default" {

## what
* Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
* Use bullet points to be concise and to the point.

## why
* Provide the justifications for the changes (e.g. business case). 
* Describe why these changes were made (e.g. why do these commits fix the problem?)
* Use bullet points to be concise and to the point.

## references
* Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
* Use `closes #123`, if this PR closes a GitHub issue `#123`

