### PR TITLE
Fix: Ensure Module Adheres var.allow_ssl_requests_only

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -109,6 +109,31 @@ data "aws_iam_policy_document" "bucket" {
       "${var.arn_format}:s3:::${module.this.id}"
     ]
   }
+
+  dynamic "statement" {
+    for_each = var.allow_ssl_requests_only ? [1] : []
+
+    content {
+      sid       = "ForceSSLOnlyAccess"
+      effect    = "Deny"
+      actions   = ["s3:*"]
+      resources = [
+        "${var.arn_format}:s3:::${module.this.id}/*",
+        "${var.arn_format}:s3:::${module.this.id}"
+      ]
+
+      principals {
+        identifiers = ["*"]
+        type        = "*"
+      }
+
+      condition {
+        test     = "Bool"
+        values   = ["false"]
+        variable = "aws:SecureTransport"
+      }
+    }
+  }
 }
 
 module "kms_key" {
@@ -138,7 +163,6 @@ module "s3_log_storage_bucket" {
   noncurrent_version_expiration_days = var.noncurrent_version_expiration_days
   noncurrent_version_transition_days = var.noncurrent_version_transition_days
   standard_transition_days           = var.standard_transition_days
-  allow_ssl_requests_only            = var.allow_ssl_requests_only
   force_destroy                      = var.force_destroy
   policy                             = join("", data.aws_iam_policy_document.bucket.*.json)
 

--- a/main.tf
+++ b/main.tf
@@ -114,9 +114,9 @@ data "aws_iam_policy_document" "bucket" {
     for_each = var.allow_ssl_requests_only ? [1] : []
 
     content {
-      sid       = "ForceSSLOnlyAccess"
-      effect    = "Deny"
-      actions   = ["s3:*"]
+      sid     = "ForceSSLOnlyAccess"
+      effect  = "Deny"
+      actions = ["s3:*"]
       resources = [
         "${var.arn_format}:s3:::${module.this.id}/*",
         "${var.arn_format}:s3:::${module.this.id}"


### PR DESCRIPTION
## what
* Ensure module adheres `var.allow_ssl_requests_only` by building out a `ForceSSLOnlyAccess` statement in the policy passed to the `s3-log-storage` module

## why
* Since this module creates its own policy and passes it to the `s3-log-storage` module, the `s3-log-storage` module will disregard `var.allow_ssl_requests_only`.

## references
* #25 

