### PR TITLE
Add kms actions

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -22,8 +22,8 @@ data "aws_iam_policy_document" "kms" {
       "kms:Untag*",
       "kms:ScheduleKeyDeletion",
       "kms:CancelKeyDeletion",
-      "kms:Decrypt*",
-      "kms:GenerateDataKey*"
+      "kms:Decrypt",
+      "kms:GenerateDataKey"
     ]
 
     resources = [

--- a/main.tf
+++ b/main.tf
@@ -26,6 +26,8 @@ data "aws_iam_policy_document" "kms" {
       "kms:GenerateDataKey"
     ]
 
+    # bridgecrew:skip=CKV_AWS_109:This policy only applies to the key it is attached to
+    # bridgecrew:skip=CKV_AWS_111:This policy only applies to the key it is attached to
     resources = [
       "*"
     ]

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,22 @@ data "aws_iam_policy_document" "kms" {
     effect = "Allow"
 
     actions = [
-      "kms:*"
+      "kms:Create*",
+      "kms:Describe*",
+      "kms:Enable*",
+      "kms:List*",
+      "kms:Put*",
+      "kms:Update*",
+      "kms:Revoke*",
+      "kms:Disable*",
+      "kms:Get*",
+      "kms:Delete*",
+      "kms:Tag*",
+      "kms:Untag*",
+      "kms:ScheduleKeyDeletion",
+      "kms:CancelKeyDeletion",
+      "kms:Decrypt*",
+      "kms:GenerateDataKey*"
     ]
 
     resources = [

--- a/main.tf
+++ b/main.tf
@@ -8,20 +8,7 @@ data "aws_iam_policy_document" "kms" {
     effect = "Allow"
 
     actions = [
-      "kms:Create*",
-      "kms:Describe*",
-      "kms:Enable*",
-      "kms:List*",
-      "kms:Put*",
-      "kms:Update*",
-      "kms:Revoke*",
-      "kms:Disable*",
-      "kms:Get*",
-      "kms:Delete*",
-      "kms:Tag*",
-      "kms:Untag*",
-      "kms:ScheduleKeyDeletion",
-      "kms:CancelKeyDeletion"
+      "kms:*"
     ]
 
     resources = [


### PR DESCRIPTION
## what
* Add permissions to allow key to be used

## why
* The current policy does not allow key to be used to access encrypted objects.  Added
```
kms:Decrypt
kms:GenerateDataKey
```
as most if not all other actions are already allowed.

## references
* Closes #30