### PR TITLE
Fix deleted variabled

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -128,8 +128,8 @@ data "aws_iam_policy_document" "bucket" {
       effect  = "Deny"
       actions = ["s3:*"]
       resources = [
-        "${var.arn_format}:s3:::${module.this.id}/*",
-        "${var.arn_format}:s3:::${module.this.id}"
+        "${local.arn_format}:s3:::${module.this.id}/*",
+        "${local.arn_format}:s3:::${module.this.id}"
       ]
 
       principals {


### PR DESCRIPTION
## what
* this PR https://github.com/cloudposse/terraform-aws-vpc-flow-logs-s3-bucket/pull/28 changed the way the arn was formatted and it does it automatically using the local `local.arn_format` and it deleted the var.arn_format variable but there were 2 references to `var.arn_format` ln the dynamic.

## why
* because it fails if you use the dynamic to force SSL.

## references
* #28

