### PR TITLE
Add 3 new input vars for make vulnerability-free buckets 

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -163,11 +163,11 @@ module "kms_key" {
 
 module "s3_log_storage_bucket" {
   source  = "cloudposse/s3-log-storage/aws"
-  version = "0.26.0"
+  version = "0.28.0"
 
   kms_master_key_arn                 = local.kms_key_arn
   sse_algorithm                      = "aws:kms"
-  versioning_enabled                 = false
+  versioning_enabled                 = var.versioning_enabled
   expiration_days                    = var.expiration_days
   glacier_transition_days            = var.glacier_transition_days
   lifecycle_prefix                   = var.lifecycle_prefix
@@ -183,7 +183,8 @@ module "s3_log_storage_bucket" {
   bucket_notifications_prefix        = var.bucket_notifications_prefix
   access_log_bucket_name             = var.access_log_bucket_name
   access_log_bucket_prefix           = var.access_log_bucket_prefix
-
+  s3_object_ownership                = var.s3_object_ownership
+  acl                                = var.acl
   context = module.this.context
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -117,3 +117,22 @@ variable "kms_key_arn" {
   description = "ARN of KMS that will be used for s3 bucket encryption."
   default     = ""
 }
+
+
+variable "versioning_enabled" {
+  type        = bool
+  description = "Enable object versioning, keeping multiple variants of an object in the same bucket"
+  default     = true
+}
+
+variable "s3_object_ownership" {
+  type        = string
+  default     = "BucketOwnerPreferred"
+  description = "Specifies the S3 object ownership control. Valid values are `ObjectWriter`, `BucketOwnerPreferred`, and 'BucketOwnerEnforced'."
+}
+
+variable "acl" {
+  type        = string
+  description = "The canned ACL to apply. We recommend log-delivery-write for compatibility with AWS services"
+  default     = "log-delivery-write"
+}


### PR DESCRIPTION
## what
Add 3 input vars related to s3 buckets where inbound and outbound trafic log is storage

- versioning_enabled
- acl
- s3_object_ownership

Upgrade to version `0.28.0` of the s3 log storage module to include the `s3_object_ownership` var.


## why
* Avoid prowler vulnerabilities in scenarios where we do not need to use acls and want the bucket to be modified only by the bucket owner.
* More detail in this issue: https://github.com/cloudposse/terraform-aws-vpc-flow-logs-s3-bucket/issues/46

## references
* This pr commit resolved #46 
* Violations overcome thanks to this pr
<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
<html>
<head>

<meta http-equiv="Content-Style-Type" content="text/css">
<meta name="Generator" content="Cocoa HTML Writer">
<meta name="CocoaVersion" content="2113.4">
</head>
<body>


Result | Severity | AccountID | Region | Compliance | Service | CheckID | Check Title | Check Output | CIS Level | CAF Epic | Risk | Remediation | Docs | Resource ID
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
PASS | Medium | xxxxxxx | us-west-2 | Software and Configuration Checks | s3 | 7.172 | [extra7172] Check if S3 buckets have ACLs enabled | us-west-2: Bucket xxxxxx-x2-ops-vpc-aws-flow-log has bucket ACLs enabled! | Extra | Logging and Monitoring | S3 ACLs are a legacy access control mechanism that predates IAM. IAM and bucket policies are currently the preferred methods. | Ensure that S3 ACLs are disabled (BucketOwnerEnforced). Use IAM policies and bucket policies to manage access. |   | xxxxxx-x2-ops-vpc-aws-flow-log
PASS | Medium | xxxxxx | us-west-2 | Software and Configuration Checks | s3 | 7.18 | [extra718] Check if S3 buckets have server access logging enabled | us-west-2: Bucket xxxxx-x2-ops-vpc-aws-flow-log has server access logging disabled! | Extra | Logging and Monitoring | Server access logs can assist you in security and access audits; help you learn about your customer base; and understand your Amazon S3 bill. | Ensure that S3 buckets have Logging enabled. CloudTrail data events can be used in place of S3 bucket logging. If that is the case; this finding can be considered a false positive. |   | xxxxxxx-x2-ops-vpc-aws-flow-log
PASS | Medium | xxxxxx | us-west-2 | Software and Configuration Checks | s3 | 7.63 | [extra763] Check if S3 buckets have object versioning enabled | us-west-2: Bucket xxxxxx-x2-ops-vpc-aws-flow-log has versioning disabled! | Extra | Data Protection | With versioning; you can easily recover from both unintended user actions and application failures. | Configure versioning using the Amazon console or API for buckets with sensitive information that is changing frecuently; and backup may not be enough to capture all the changes. |   | xxxxxx-x2-ops-vpc-aws-flow-log


</body>
</html>

* Inputs
```
inputs = {
  name                   = local.bucket_name
  traffic_type	         = "ALL"
  vpc_id                 = dependency.vpc.outputs.vpc_id 
  enabled                = true
  versioning_enabled     = true
  access_log_bucket_name = local.bucket_name
  allow_ssl_requests_only= true
  s3_object_ownership    = "BucketOwnerEnforced"
  acl                    = "private"
  
  additional_tag_map     = {
    ops_env              = local.account_name
    ops_managed_by       = "terraform"
    ops_source_repo      = "gruntwork-infrastructure-live"
    ops_source_repo_path = "${path_relative_to_include()}"
    ops_owners           = "devops"
  }
}

```
* Terraform apply
```
Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create
 <= read (data resources)

Terraform will perform the following actions:

  # aws_flow_log.default[0] will be created
  + resource "aws_flow_log" "default" {
      + arn                      = (known after apply)
      + id                       = (known after apply)
      + log_destination          = (known after apply)
      + log_destination_type     = "s3"
      + log_format               = (known after apply)
      + log_group_name           = (known after apply)
      + max_aggregation_interval = 600
      + tags_all                 = (known after apply)
      + traffic_type             = "ALL"
      + vpc_id                   = "vpc-0254921a46bca1455"
    }

  # module.kms_key.aws_kms_alias.default[0] will be created
  + resource "aws_kms_alias" "default" {
      + arn            = (known after apply)
      + id             = (known after apply)
      + name           = "alias/xxxxxxx-x2-ops-vpc-aws-flow-log"
      + name_prefix    = (known after apply)
      + target_key_arn = (known after apply)
      + target_key_id  = (known after apply)
    }

  # module.kms_key.aws_kms_key.default[0] will be created
  + resource "aws_kms_key" "default" {
      + arn                                = (known after apply)
      + bypass_policy_lockout_safety_check = false
      + customer_master_key_spec           = "SYMMETRIC_DEFAULT"
      + deletion_window_in_days            = 10
      + description                        = "KMS key for VPC Flow Logs"
      + enable_key_rotation                = true
      + id                                 = (known after apply)
      + is_enabled                         = true
      + key_id                             = (known after apply)
      + key_usage                          = "ENCRYPT_DECRYPT"
      + multi_region                       = false
      + policy                             = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = [
                          + "kms:Update*",
                          + "kms:Untag*",
                          + "kms:Tag*",
                          + "kms:ScheduleKeyDeletion",
                          + "kms:Revoke*",
                          + "kms:Put*",
                          + "kms:List*",
                          + "kms:Get*",
                          + "kms:Enable*",
                          + "kms:Disable*",
                          + "kms:Describe*",
                          + "kms:Delete*",
                          + "kms:Create*",
                          + "kms:CancelKeyDeletion",
                        ]
                      + Effect    = "Allow"
                      + Principal = {
                          + AWS = "arn:aws:iam::xxxxx:root"
                        }
                      + Resource  = "*"
                      + Sid       = "Enable Root User Permissions"
                    },
                  + {
                      + Action    = [
                          + "kms:ReEncrypt*",
                          + "kms:GenerateDataKey*",
                          + "kms:Encrypt*",
                          + "kms:Describe*",
                          + "kms:Decrypt*",
                        ]
                      + Effect    = "Allow"
                      + Principal = {
                          + Service = "delivery.logs.amazonaws.com"
                        }
                      + Resource  = "*"
                      + Sid       = "Allow VPC Flow Logs to use the key"
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + tags                               = {
          + "Name" = “xxxxx-x2-ops-vpc-aws-flow-log"
        }
      + tags_all                           = {
          + "Name" = “xxxxxxx-x2-ops-vpc-aws-flow-log"
        }
    }

  # module.s3_log_storage_bucket.module.aws_s3_bucket.data.aws_iam_policy_document.aggregated_policy[0] will be read during apply
  # (config refers to values not yet known)
 <= data "aws_iam_policy_document" "aggregated_policy"  {
      + id                        = (known after apply)
      + json                      = (known after apply)
      + override_policy_documents = [
          + jsonencode(
                {
                  + Statement = [
                      + {
                          + Action    = "s3:PutObject"
                          + Condition = {
                              + StringEquals = {
                                  + s3:x-amz-acl = "bucket-owner-full-control"
                                }
                            }
                          + Effect    = "Allow"
                          + Principal = {
                              + Service = "delivery.logs.amazonaws.com"
                            }
                          + Resource  = "arn:aws:s3:::xxxxxx-x2-ops-vpc-aws-flow-log/*"
                          + Sid       = "AWSLogDeliveryWrite"
                        },
                      + {
                          + Action    = "s3:GetBucketAcl"
                          + Effect    = "Allow"
                          + Principal = {
                              + Service = "delivery.logs.amazonaws.com"
                            }
                          + Resource  = "arn:aws:s3:::xxxxxxxx-x2-ops-vpc-aws-flow-log"
                          + Sid       = "AWSLogDeliveryAclCheck"
                        },
                      + {
                          + Action    = "s3:*"
                          + Condition = {
                              + Bool = {
                                  + aws:SecureTransport = "false"
                                }
                            }
                          + Effect    = "Deny"
                          + Principal = "*"
                          + Resource  = [
                              + "arn:aws:s3:::xxxxxxx-x2-ops-vpc-aws-flow-log/*",
                              + "arn:aws:s3:::xxxxxxx-x2-ops-vpc-aws-flow-log",
                            ]
                          + Sid       = "ForceSSLOnlyAccess"
                        },
                    ]
                  + Version   = "2012-10-17"
                }
            ),
        ]
      + source_policy_documents   = [
          + (known after apply),
        ]
    }

  # module.s3_log_storage_bucket.module.aws_s3_bucket.data.aws_iam_policy_document.bucket_policy[0] will be read during apply
  # (config refers to values not yet known)
 <= data "aws_iam_policy_document" "bucket_policy"  {
      + id   = (known after apply)
      + json = (known after apply)

      + statement {
          + actions   = [
              + "s3:*",
            ]
          + effect    = "Deny"
          + resources = [
              + (known after apply),
              + (known after apply),
            ]
          + sid       = "ForceSSLOnlyAccess"

          + condition {
              + test     = "Bool"
              + values   = [
                  + "false",
                ]
              + variable = "aws:SecureTransport"
            }

          + principals {
              + identifiers = [
                  + "*",
                ]
              + type        = "*"
            }
        }
    }

  # module.s3_log_storage_bucket.module.aws_s3_bucket.aws_s3_bucket.default[0] will be created
  + resource "aws_s3_bucket" "default" {
      + acceleration_status         = (known after apply)
      + acl                         = (known after apply)
      + arn                         = (known after apply)
      + bucket                      = “xxxxxxx-x2-ops-vpc-aws-flow-log"
      + bucket_domain_name          = (known after apply)
      + bucket_regional_domain_name = (known after apply)
      + force_destroy               = false
      + hosted_zone_id              = (known after apply)
      + id                          = (known after apply)
      + object_lock_enabled         = (known after apply)
      + policy                      = (known after apply)
      + region                      = (known after apply)
      + request_payer               = (known after apply)
      + tags                        = {
          + "Name" = “xxxxxx-x2-ops-vpc-aws-flow-log"
        }
      + tags_all                    = {
          + "Name" = “xxxxxxx-x2-ops-vpc-aws-flow-log"
        }
      + website_domain              = (known after apply)
      + website_endpoint            = (known after apply)

      + cors_rule {
          + allowed_headers = (known after apply)
          + allowed_methods = (known after apply)
          + allowed_origins = (known after apply)
          + expose_headers  = (known after apply)
          + max_age_seconds = (known after apply)
        }

      + grant {
          + id          = (known after apply)
          + permissions = (known after apply)
          + type        = (known after apply)
          + uri         = (known after apply)
        }

      + lifecycle_rule {
          + abort_incomplete_multipart_upload_days = (known after apply)
          + enabled                                = (known after apply)
          + id                                     = (known after apply)
          + prefix                                 = (known after apply)
          + tags                                   = (known after apply)

          + expiration {
              + date                         = (known after apply)
              + days                         = (known after apply)
              + expired_object_delete_marker = (known after apply)
            }

          + noncurrent_version_expiration {
              + days = (known after apply)
            }

          + noncurrent_version_transition {
              + days          = (known after apply)
              + storage_class = (known after apply)
            }

          + transition {
              + date          = (known after apply)
              + days          = (known after apply)
              + storage_class = (known after apply)
            }
        }

      + logging {
          + target_bucket = (known after apply)
          + target_prefix = (known after apply)
        }

      + object_lock_configuration {
          + object_lock_enabled = (known after apply)

          + rule {
              + default_retention {
                  + days  = (known after apply)
                  + mode  = (known after apply)
                  + years = (known after apply)
                }
            }
        }

      + replication_configuration {
          + role = (known after apply)

          + rules {
              + delete_marker_replication_status = (known after apply)
              + id                               = (known after apply)
              + prefix                           = (known after apply)
              + priority                         = (known after apply)
              + status                           = (known after apply)

              + destination {
                  + account_id         = (known after apply)
                  + bucket             = (known after apply)
                  + replica_kms_key_id = (known after apply)
                  + storage_class      = (known after apply)

                  + access_control_translation {
                      + owner = (known after apply)
                    }

                  + metrics {
                      + minutes = (known after apply)
                      + status  = (known after apply)
                    }

                  + replication_time {
                      + minutes = (known after apply)
                      + status  = (known after apply)
                    }
                }

              + filter {
                  + prefix = (known after apply)
                  + tags   = (known after apply)
                }

              + source_selection_criteria {
                  + sse_kms_encrypted_objects {
                      + enabled = (known after apply)
                    }
                }
            }
        }

      + server_side_encryption_configuration {
          + rule {
              + bucket_key_enabled = (known after apply)

              + apply_server_side_encryption_by_default {
                  + kms_master_key_id = (known after apply)
                  + sse_algorithm     = (known after apply)
                }
            }
        }

      + versioning {
          + enabled    = (known after apply)
          + mfa_delete = (known after apply)
        }

      + website {
          + error_document           = (known after apply)
          + index_document           = (known after apply)
          + redirect_all_requests_to = (known after apply)
          + routing_rules            = (known after apply)
        }
    }

  # module.s3_log_storage_bucket.module.aws_s3_bucket.aws_s3_bucket_acl.default[0] will be created
  + resource "aws_s3_bucket_acl" "default" {
      + acl    = "private"
      + bucket = (known after apply)
      + id     = (known after apply)

      + access_control_policy {
          + grant {
              + permission = (known after apply)

              + grantee {
                  + display_name  = (known after apply)
                  + email_address = (known after apply)
                  + id            = (known after apply)
                  + type          = (known after apply)
                  + uri           = (known after apply)
                }
            }

          + owner {
              + display_name = (known after apply)
              + id           = (known after apply)
            }
        }
    }

  # module.s3_log_storage_bucket.module.aws_s3_bucket.aws_s3_bucket_lifecycle_configuration.default[0] will be created
  + resource "aws_s3_bucket_lifecycle_configuration" "default" {
      + bucket = (known after apply)
      + id     = (known after apply)

      + rule {
          + id     = “xxxxxxx-x2-ops-vpc-aws-flow-log"
          + status = "Enabled"

          + abort_incomplete_multipart_upload {
              + days_after_initiation = 5
            }

          + expiration {
              + days                         = 90
              + expired_object_delete_marker = (known after apply)
            }

          + filter {
            }

          + noncurrent_version_expiration {
              + noncurrent_days = 90
            }

          + noncurrent_version_transition {
              + noncurrent_days = 30
              + storage_class   = "GLACIER"
            }

          + transition {
              + days          = 30
              + storage_class = "STANDARD_IA"
            }
          + transition {
              + days          = 60
              + storage_class = "GLACIER"
            }
        }
    }

  # module.s3_log_storage_bucket.module.aws_s3_bucket.aws_s3_bucket_logging.default[0] will be created
  + resource "aws_s3_bucket_logging" "default" {
      + bucket        = (known after apply)
      + id            = (known after apply)
      + target_bucket = “xxxxxx-x2-ops-vpc-aws-flow-log"
      + target_prefix = "logs/xxxxxxx-x2-ops-vpc-aws-flow-log/"
    }

  # module.s3_log_storage_bucket.module.aws_s3_bucket.aws_s3_bucket_ownership_controls.default[0] will be created
  + resource "aws_s3_bucket_ownership_controls" "default" {
      + bucket = (known after apply)
      + id     = (known after apply)

      + rule {
          + object_ownership = "BucketOwnerEnforced"
        }
    }

  # module.s3_log_storage_bucket.module.aws_s3_bucket.aws_s3_bucket_policy.default[0] will be created
  + resource "aws_s3_bucket_policy" "default" {
      + bucket = (known after apply)
      + id     = (known after apply)
      + policy = (known after apply)
    }

  # module.s3_log_storage_bucket.module.aws_s3_bucket.aws_s3_bucket_public_access_block.default[0] will be created
  + resource "aws_s3_bucket_public_access_block" "default" {
      + block_public_acls       = true
      + block_public_policy     = true
      + bucket                  = (known after apply)
      + id                      = (known after apply)
      + ignore_public_acls      = true
      + restrict_public_buckets = true
    }

  # module.s3_log_storage_bucket.module.aws_s3_bucket.aws_s3_bucket_server_side_encryption_configuration.default[0] will be created
  + resource "aws_s3_bucket_server_side_encryption_configuration" "default" {
      + bucket = (known after apply)
      + id     = (known after apply)

      + rule {
          + bucket_key_enabled = false

          + apply_server_side_encryption_by_default {
              + kms_master_key_id = (known after apply)
              + sse_algorithm     = "aws:kms"
            }
        }
    }

  # module.s3_log_storage_bucket.module.aws_s3_bucket.aws_s3_bucket_versioning.default[0] will be created
  + resource "aws_s3_bucket_versioning" "default" {
      + bucket = (known after apply)
      + id     = (known after apply)

      + versioning_configuration {
          + mfa_delete = (known after apply)
          + status     = "Enabled"
        }
    }

  # module.s3_log_storage_bucket.module.aws_s3_bucket.time_sleep.wait_for_aws_s3_bucket_settings[0] will be created
  + resource "time_sleep" "wait_for_aws_s3_bucket_settings" {
      + create_duration  = "30s"
      + destroy_duration = "30s"
      + id               = (known after apply)
    }

Plan: 13 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + bucket_arn         = (known after apply)
  + bucket_domain_name = (known after apply)
  + bucket_id          = (known after apply)
  + flow_log_arn       = (known after apply)
  + flow_log_id        = (known after apply)
  + kms_alias_arn      = (known after apply)
  + kms_alias_name     = "alias/xxxxx-x2-ops-vpc-aws-flow-log"
  + kms_key_arn        = (known after apply)
  + kms_key_id         = (known after apply)
╷
│ Warning: Argument is deprecated
│ 
│   with data.aws_iam_policy_document.kms,
│   on main.tf line 14, in data "aws_iam_policy_document" "kms":
│   14:   source_json = var.kms_policy_source_json
│ 
│ Use the attribute "source_policy_documents" instead.
│ 
│ (and 2 more similar warnings elsewhere)
╵

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

module.kms_key.aws_kms_key.default[0]: Creating...
module.s3_log_storage_bucket.module.aws_s3_bucket.aws_s3_bucket.default[0]: Creating...
module.s3_log_storage_bucket.module.aws_s3_bucket.aws_s3_bucket.default[0]: Creation complete after 4s [id=xxxxxx-x2-ops-vpc-aws-flow-log]
module.s3_log_storage_bucket.module.aws_s3_bucket.data.aws_iam_policy_document.bucket_policy[0]: Reading...
aws_flow_log.default[0]: Creating...
module.s3_log_storage_bucket.module.aws_s3_bucket.aws_s3_bucket_versioning.default[0]: Creating...
module.s3_log_storage_bucket.module.aws_s3_bucket.aws_s3_bucket_public_access_block.default[0]: Creating...
module.s3_log_storage_bucket.module.aws_s3_bucket.data.aws_iam_policy_document.bucket_policy[0]: Read complete after 0s [id=2250367513]
module.s3_log_storage_bucket.module.aws_s3_bucket.data.aws_iam_policy_document.aggregated_policy[0]: Reading...
module.s3_log_storage_bucket.module.aws_s3_bucket.aws_s3_bucket_acl.default[0]: Creating...
module.s3_log_storage_bucket.module.aws_s3_bucket.aws_s3_bucket_logging.default[0]: Creating...
module.s3_log_storage_bucket.module.aws_s3_bucket.data.aws_iam_policy_document.aggregated_policy[0]: Read complete after 0s [id=2379174012]
module.s3_log_storage_bucket.module.aws_s3_bucket.aws_s3_bucket_acl.default[0]: Creation complete after 1s [id=xxxxx-x2-ops-vpc-aws-flow-log,private]
aws_flow_log.default[0]: Creation complete after 1s [id=fl-076cbd5aecff3e9aa]
module.s3_log_storage_bucket.module.aws_s3_bucket.aws_s3_bucket_logging.default[0]: Creation complete after 1s [id=xxxxx-x2-ops-vpc-aws-flow-log]
module.s3_log_storage_bucket.module.aws_s3_bucket.aws_s3_bucket_versioning.default[0]: Creation complete after 2s [id=xxxxx-x2-ops-vpc-aws-flow-log]
module.s3_log_storage_bucket.module.aws_s3_bucket.aws_s3_bucket_lifecycle_configuration.default[0]: Creating...
module.s3_log_storage_bucket.module.aws_s3_bucket.aws_s3_bucket_public_access_block.default[0]: Creation complete after 2s [id=xxxxx-x2-ops-vpc-aws-flow-log]
module.s3_log_storage_bucket.module.aws_s3_bucket.aws_s3_bucket_policy.default[0]: Creating...
module.s3_log_storage_bucket.module.aws_s3_bucket.aws_s3_bucket_policy.default[0]: Creation complete after 0s [id=xxxx-x2-ops-vpc-aws-flow-log]
module.s3_log_storage_bucket.module.aws_s3_bucket.time_sleep.wait_for_aws_s3_bucket_settings[0]: Creating...
module.kms_key.aws_kms_key.default[0]: Still creating... [10s elapsed]
module.kms_key.aws_kms_key.default[0]: Creation complete after 15s [id=3df59e1d-449c-4f30-8fb3-20adcca8c55a]
module.kms_key.aws_kms_alias.default[0]: Creating...
module.kms_key.aws_kms_alias.default[0]: Creation complete after 0s [id=alias/xxxxx-x2-ops-vpc-aws-flow-log]
module.s3_log_storage_bucket.module.aws_s3_bucket.aws_s3_bucket_server_side_encryption_configuration.default[0]: Creating...
module.s3_log_storage_bucket.module.aws_s3_bucket.aws_s3_bucket_lifecycle_configuration.default[0]: Still creating... [10s elapsed]
module.s3_log_storage_bucket.module.aws_s3_bucket.time_sleep.wait_for_aws_s3_bucket_settings[0]: Still creating... [10s elapsed]
module.s3_log_storage_bucket.module.aws_s3_bucket.aws_s3_bucket_server_side_encryption_configuration.default[0]: Creation complete after 2s [id=xxxxxx-x2-ops-vpc-aws-flow-log]
module.s3_log_storage_bucket.module.aws_s3_bucket.aws_s3_bucket_lifecycle_configuration.default[0]: Still creating... [20s elapsed]
module.s3_log_storage_bucket.module.aws_s3_bucket.time_sleep.wait_for_aws_s3_bucket_settings[0]: Still creating... [20s elapsed]
module.s3_log_storage_bucket.module.aws_s3_bucket.aws_s3_bucket_lifecycle_configuration.default[0]: Still creating... [30s elapsed]
module.s3_log_storage_bucket.module.aws_s3_bucket.time_sleep.wait_for_aws_s3_bucket_settings[0]: Creation complete after 30s [id=2022-06-23T00:53:42Z]
module.s3_log_storage_bucket.module.aws_s3_bucket.aws_s3_bucket_ownership_controls.default[0]: Creating...
module.s3_log_storage_bucket.module.aws_s3_bucket.aws_s3_bucket_ownership_controls.default[0]: Creation complete after 1s [id=xxxxxx-x2-ops-vpc-aws-flow-log]
module.s3_log_storage_bucket.module.aws_s3_bucket.aws_s3_bucket_lifecycle_configuration.default[0]: Creation complete after 32s [id=xxxxxx-x2-ops-vpc-aws-flow-log]
Releasing state lock. This may take a few moments...

Apply complete! Resources: 13 added, 0 changed, 0 destroyed.

Outputs:

bucket_arn = "arn:aws:s3:::xxxxxx-x2-ops-vpc-aws-flow-log"
bucket_domain_name = “xxxxxx-x2-ops-vpc-aws-flow-log.s3.amazonaws.com"
bucket_id = “xxxxx-x2-ops-vpc-aws-flow-log"
bucket_notifications_sqs_queue_arn = ""
bucket_prefix = ""
flow_log_arn = "arn:aws:ec2:us-west-2:xxxxxx:vpc-flow-log/fl-076cbd5aecff3e9aa"
flow_log_id = "fl-076cbd5aecff3e9aa"
kms_alias_arn = "arn:aws:kms:us-west-2:xxxxxxxx:alias/xxxxxx-x2-ops-vpc-aws-flow-log"
kms_alias_name = "alias/xxxxxxx-x2-ops-vpc-aws-flow-log"
kms_key_arn = "arn:aws:kms:us-west-2:xxxxx:key/3df59e1d-449c-4f30-8fb3-20adcca8c55a"
kms_key_id = "3df59e1d-449c-4f30-8fb3-20adcca8c55a"
```
