### PR TITLE
Remove reference to TF_DATA_DIR added by mistake in #54

### DIFF
--- a/test/src/Makefile
+++ b/test/src/Makefile
@@ -26,4 +26,4 @@ docker/test:
 .PHONY : clean
 ## Clean up files
 clean:
-	rm -rf $(TF_DATA_DIR) ../../examples/complete/*.tfstate*
+	rm -rf ../../examples/complete/*.tfstate*


### PR DESCRIPTION
## what

- Remove reference to `TF_DATA_DIR` in `test/src/Makefile` added by mistake in #54

## why

- Added by mistake, has potential for abuse or innocent misuse to cause big problems

