### PR TITLE
chore(deps): update terraform cloudposse/s3-log-storage/aws to v1.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Available targets:
 |------|--------|---------|
 | <a name="module_bucket_name"></a> [bucket\_name](#module\_bucket\_name) | cloudposse/label/null | 0.25.0 |
 | <a name="module_kms_key"></a> [kms\_key](#module\_kms\_key) | cloudposse/kms-key/aws | 0.12.1 |
-| <a name="module_s3_log_storage_bucket"></a> [s3\_log\_storage\_bucket](#module\_s3\_log\_storage\_bucket) | cloudposse/s3-log-storage/aws | 1.3.1 |
+| <a name="module_s3_log_storage_bucket"></a> [s3\_log\_storage\_bucket](#module\_s3\_log\_storage\_bucket) | cloudposse/s3-log-storage/aws | 1.4.1 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 
 ## Resources

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -18,7 +18,7 @@
 |------|--------|---------|
 | <a name="module_bucket_name"></a> [bucket\_name](#module\_bucket\_name) | cloudposse/label/null | 0.25.0 |
 | <a name="module_kms_key"></a> [kms\_key](#module\_kms\_key) | cloudposse/kms-key/aws | 0.12.1 |
-| <a name="module_s3_log_storage_bucket"></a> [s3\_log\_storage\_bucket](#module\_s3\_log\_storage\_bucket) | cloudposse/s3-log-storage/aws | 1.3.1 |
+| <a name="module_s3_log_storage_bucket"></a> [s3\_log\_storage\_bucket](#module\_s3\_log\_storage\_bucket) | cloudposse/s3-log-storage/aws | 1.4.1 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 
 ## Resources

--- a/main.tf
+++ b/main.tf
@@ -199,7 +199,7 @@ module "kms_key" {
 
 module "s3_log_storage_bucket" {
   source  = "cloudposse/s3-log-storage/aws"
-  version = "1.3.1"
+  version = "1.4.1"
 
   bucket_name = local.bucket_name
 


### PR DESCRIPTION
## what

Now the aws_s3_bucket_acl resource will wait for the aws_s3_bucket_ownership_controls resource to be finished

## why

- Because of the [recent AWS changes to default values on new S3 buckets](https://aws.amazon.com/blogs/aws/heads-up-amazon-s3-security-changes-are-coming-in-april-of-2023/), all new s3 buckets start out with the `ObjectOwnership` set to `BucketOwnerEnforced`.
- This means that when we try to create the `aws_s3_bucket_acl` resource on a brand new S3 bucket, we will always get `AccessControlListNotSupported: The bucket does not allow ACLs`
- Waiting for the `aws_s3_bucket_ownership_controls` to exist guarantees that if the ACL is supposed to be created, it can be created because now the bucket will allow ACLs (For example, with the `BucketOwnerPreferred` or `ObjectWriter` ownership settings now applied)

## references

- https://github.com/cloudposse/terraform-aws-s3-bucket/issues/174
- https://aws.amazon.com/blogs/aws/heads-up-amazon-s3-security-changes-are-coming-in-april-of-2023/
- https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html
