### PR TITLE
SID should be alphanumeric only

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -33,7 +33,7 @@ data "aws_iam_policy_document" "kms" {
   source_policy_documents = [var.kms_policy_source_json]
 
   statement {
-    sid    = "Enable Root User Permissions"
+    sid    = "EnableRootUserPermissions"
     effect = "Allow"
 
     actions = [
@@ -69,7 +69,7 @@ data "aws_iam_policy_document" "kms" {
   }
 
   statement {
-    sid    = "Allow VPC Flow Logs to use the key"
+    sid    = "AllowVPCFlowLogstousethekey"
     effect = "Allow"
 
     actions = [


### PR DESCRIPTION
## what

Fixing:

```
│ Error: invalid value for statement.0.sid (must only include alphanumeric characters)
│ 
│   with module.flow_logs.data.aws_iam_policy_document.kms[0],
│   on .terraform/modules/flow_logs/main.tf line 36, in data "aws_iam_policy_document" "kms":
│   36:     sid    = "Enable Root User Permissions"
│ 
╵
╷
│ Error: invalid value for statement.1.sid (must only include alphanumeric characters)
│ 
│   with module.flow_logs.data.aws_iam_policy_document.kms[0],
│   on .terraform/modules/flow_logs/main.tf line 72, in data "aws_iam_policy_document" "kms":
│   72:     sid    = "Allow VPC Flow Logs to use the key"
```

by making the `sid` values alphanumeric (and omitting the whitespace)

## why

This is preventing me from planning and applying my infrastructure. I am using terraform `v1.9.2`

## references
