### PR TITLE
fix: correct flow-logs delivery policy for BucketOwnerEnforced + add cross-account scoping

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,20 @@ The module will create:
 * KMS key to encrypt flow logs files in the bucket
 * Optional VPC Flow Log backed by the S3 bucket (this can be disabled, e.g. in multi-account environments if you want to create an S3 bucket in one account and VPC Flow Logs in different accounts)
 
+**Cross-account / multi-account delivery**: When centralizing VPC Flow Logs from multiple
+AWS accounts into a single Log Archive account, set either `flow_logs_source_org_id`
+(to authorize all accounts in an AWS Organization) or `flow_logs_source_account_ids`
+(to list individual accounts). These add `aws:SourceOrgID` / `aws:SourceAccount` +
+`aws:SourceArn` conditions to the bucket delivery policy for confused-deputy protection.
+The KMS key policy is scoped with the same `aws:SourceOrgID` / `aws:SourceAccount` conditions
+so cross-account key usage is equally protected.
+
+**`BucketOwnerEnforced` compatibility**: When `s3_object_ownership` is `BucketOwnerEnforced`
+(the recommended setting, and the default when `null` is passed), the module omits the
+`s3:x-amz-acl` condition from the `AWSLogDeliveryWrite` policy statement. With ACLs
+disabled, the delivery service sends no ACL header, so a `StringEquals s3:x-amz-acl`
+condition would never match and would silently deny all log writes.
+
 
 
 
@@ -155,6 +169,8 @@ For automated tests of the complete example using [bats](https://github.com/bats
 | <a name="input_environment"></a> [environment](#input\_environment) | ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | <a name="input_expiration_days"></a> [expiration\_days](#input\_expiration\_days) | (Deprecated, use `lifecycle_configuration_rules` instead)<br/>Number of days after which to expunge the objects | `number` | `null` | no |
 | <a name="input_flow_log_enabled"></a> [flow\_log\_enabled](#input\_flow\_log\_enabled) | Enable/disable the Flow Log creation. Useful in multi-account environments where the bucket is in one account, but VPC Flow Logs are in different accounts | `bool` | `true` | no |
+| <a name="input_flow_logs_source_account_ids"></a> [flow\_logs\_source\_account\_ids](#input\_flow\_logs\_source\_account\_ids) | List of AWS account IDs that are authorized to deliver VPC Flow Logs to this bucket.<br/>When set, adds `aws:SourceAccount` and `aws:SourceArn` conditions to the bucket delivery policy<br/>statements, preventing confused-deputy attacks and enabling cross-account log delivery.<br/>Multiple accounts may be listed (e.g., all spoke accounts in a landing zone).<br/>When both `flow_logs_source_account_ids` and `flow_logs_source_org_id` are empty (the default),<br/>no source conditions are added and the policy permits delivery from any account — this preserves<br/>backward compatibility for single-account deployments. | `list(string)` | `[]` | no |
+| <a name="input_flow_logs_source_org_id"></a> [flow\_logs\_source\_org\_id](#input\_flow\_logs\_source\_org\_id) | AWS Organizations ID (e.g. `o-xxxxxxxxxx`) whose member accounts are authorized to deliver<br/>VPC Flow Logs to this bucket. When set, adds an `aws:SourceOrgID` condition to the bucket<br/>delivery policy statements. This is the simplest way to authorize all accounts in an<br/>organization without listing each account individually.<br/>Takes precedence over `flow_logs_source_account_ids` when both are set.<br/>When empty (the default), no source condition is added — backward-compatible for<br/>single-account deployments. | `string` | `""` | no |
 | <a name="input_force_destroy"></a> [force\_destroy](#input\_force\_destroy) | A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable | `bool` | `false` | no |
 | <a name="input_glacier_transition_days"></a> [glacier\_transition\_days](#input\_glacier\_transition\_days) | (Deprecated, use `lifecycle_configuration_rules` instead)<br/>Number of days after which to move the data to the Glacier Flexible Retrieval storage tier | `number` | `null` | no |
 | <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br/>Set to `0` for unlimited length.<br/>Set to `null` for keep the existing setting, which defaults to `0`.<br/>Does not affect `id_full`. | `number` | `null` | no |
@@ -368,3 +384,4 @@ Copyright © 2017-2025 [Cloud Posse, LLC](https://cpco.io/copyright)
 <a href="https://cloudposse.com/readme/footer/link?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-vpc-flow-logs-s3-bucket&utm_content=readme_footer_link"><img alt="README footer" src="https://cloudposse.com/readme/footer/img"/></a>
 
 <img alt="Beacon" width="0" src="https://ga-beacon.cloudposse.com/UA-76589703-4/cloudposse/terraform-aws-vpc-flow-logs-s3-bucket?pixel&cs=github&cm=readme&an=terraform-aws-vpc-flow-logs-s3-bucket"/>
+

--- a/README.yaml
+++ b/README.yaml
@@ -51,6 +51,8 @@ introduction: |-
   (to authorize all accounts in an AWS Organization) or `flow_logs_source_account_ids`
   (to list individual accounts). These add `aws:SourceOrgID` / `aws:SourceAccount` +
   `aws:SourceArn` conditions to the bucket delivery policy for confused-deputy protection.
+  The KMS key policy is scoped with the same `aws:SourceOrgID` / `aws:SourceAccount` conditions
+  so cross-account key usage is equally protected.
 
   **`BucketOwnerEnforced` compatibility**: When `s3_object_ownership` is `BucketOwnerEnforced`
   (the recommended setting, and the default when `null` is passed), the module omits the
@@ -80,7 +82,7 @@ usage: |-
 
     module "flow_logs" {
       source  = "cloudposse/vpc-flow-logs-s3-bucket/aws"
-      version = "0.9.0"
+      version = "0.8.0"
 
       namespace  = "eg"
       stage      = "test"
@@ -95,7 +97,7 @@ usage: |-
     # Deployed in the Log Archive account; VPC Flow Logs created in spoke accounts.
     module "flow_logs_bucket" {
       source  = "cloudposse/vpc-flow-logs-s3-bucket/aws"
-      version = "0.9.0"
+      version = "0.8.0"
 
       namespace  = "eg"
       stage      = "prod"

--- a/README.yaml
+++ b/README.yaml
@@ -46,6 +46,18 @@ introduction: |-
   * KMS key to encrypt flow logs files in the bucket
   * Optional VPC Flow Log backed by the S3 bucket (this can be disabled, e.g. in multi-account environments if you want to create an S3 bucket in one account and VPC Flow Logs in different accounts)
 
+  **Cross-account / multi-account delivery**: When centralizing VPC Flow Logs from multiple
+  AWS accounts into a single Log Archive account, set either `flow_logs_source_org_id`
+  (to authorize all accounts in an AWS Organization) or `flow_logs_source_account_ids`
+  (to list individual accounts). These add `aws:SourceOrgID` / `aws:SourceAccount` +
+  `aws:SourceArn` conditions to the bucket delivery policy for confused-deputy protection.
+
+  **`BucketOwnerEnforced` compatibility**: When `s3_object_ownership` is `BucketOwnerEnforced`
+  (the recommended setting, and the default when `null` is passed), the module omits the
+  `s3:x-amz-acl` condition from the `AWSLogDeliveryWrite` policy statement. With ACLs
+  disabled, the delivery service sends no ACL header, so a `StringEquals s3:x-amz-acl`
+  condition would never match and would silently deny all log writes.
+
 # How to use this project
 usage: |-
   For a complete example, see [examples/complete](examples/complete).
@@ -54,6 +66,7 @@ usage: |-
   (which tests and deploys the example on Datadog), see [test](test).
 
 
+  Single-account (same account as bucket):
   ```hcl
     module "vpc" {
       source  = "cloudposse/vpc/aws"
@@ -67,13 +80,36 @@ usage: |-
 
     module "flow_logs" {
       source  = "cloudposse/vpc-flow-logs-s3-bucket/aws"
-      version = "0.8.0"
+      version = "0.9.0"
 
       namespace  = "eg"
       stage      = "test"
       name       = "flowlogs"
 
       vpc_id = module.vpc.vpc_id
+    }
+  ```
+
+  Multi-account, org-wide (e.g. Log Archive bucket receiving logs from all accounts):
+  ```hcl
+    # Deployed in the Log Archive account; VPC Flow Logs created in spoke accounts.
+    module "flow_logs_bucket" {
+      source  = "cloudposse/vpc-flow-logs-s3-bucket/aws"
+      version = "0.9.0"
+
+      namespace  = "eg"
+      stage      = "prod"
+      name       = "flowlogs"
+
+      # Disable the inline flow log resource — spoke accounts create their own.
+      flow_log_enabled = false
+
+      # Authorize all accounts in the org to deliver logs to this bucket.
+      flow_logs_source_org_id = "o-xxxxxxxxxx"
+
+      # BucketOwnerEnforced (default) disables ACLs; the module omits the
+      # s3:x-amz-acl condition automatically to allow delivery to succeed.
+      s3_object_ownership = null
     }
   ```
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -26,6 +26,8 @@ module "flow_logs" {
   allow_ssl_requests_only            = var.allow_ssl_requests_only
   vpc_id                             = module.vpc.vpc_id
   kms_key_arn                        = var.kms_key_arn
+  flow_logs_source_org_id            = var.flow_logs_source_org_id
+  flow_logs_source_account_ids       = var.flow_logs_source_account_ids
 
   # For testing
   force_destroy = true

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -74,3 +74,15 @@ variable "kms_key_arn" {
   default     = ""
   description = "If provided will be used for the S3 bucket encryption. If not provided a KMS will be created for you."
 }
+
+variable "flow_logs_source_org_id" {
+  type        = string
+  description = "AWS Organizations ID authorized to deliver VPC Flow Logs to this bucket. Leave empty for single-account deployments."
+  default     = ""
+}
+
+variable "flow_logs_source_account_ids" {
+  type        = list(string)
+  description = "List of AWS account IDs authorized to deliver VPC Flow Logs to this bucket. Leave empty for single-account deployments."
+  default     = []
+}

--- a/main.tf
+++ b/main.tf
@@ -295,7 +295,7 @@ module "kms_key" {
   description             = "KMS key for VPC Flow Logs"
   deletion_window_in_days = 10
   enable_key_rotation     = true
-  policy                  = join("", data.aws_iam_policy_document.kms.*.json)
+  policy                  = join("", data.aws_iam_policy_document.kms[*].json)
 
   context = module.this.context
 
@@ -321,7 +321,7 @@ module "s3_log_storage_bucket" {
 
   acl                     = var.acl
   s3_object_ownership     = local.effective_ownership
-  source_policy_documents = data.aws_iam_policy_document.bucket.*.json
+  source_policy_documents = data.aws_iam_policy_document.bucket[*].json
 
   bucket_notifications_enabled = var.bucket_notifications_enabled
   bucket_notifications_type    = var.bucket_notifications_type

--- a/main.tf
+++ b/main.tf
@@ -10,6 +10,20 @@ locals {
   lifecycle_configuration_rules = (local.deprecated_lifecycle_rule.enabled ?
     tolist(concat(var.lifecycle_configuration_rules, [local.deprecated_lifecycle_rule])) : var.lifecycle_configuration_rules
   )
+
+  # Effective object ownership: null input selects the recommended BucketOwnerEnforced.
+  effective_ownership = var.s3_object_ownership == null ? "BucketOwnerEnforced" : var.s3_object_ownership
+
+  # With BucketOwnerEnforced, S3 has ACLs entirely disabled. The log-delivery service
+  # does not send the x-amz-acl header in that mode, so a StringEquals condition on
+  # s3:x-amz-acl will never match and will silently deny all writes.  Only include the
+  # ACL condition for ownership modes that still have ACLs enabled.
+  acl_condition_required = local.effective_ownership != "BucketOwnerEnforced"
+
+  # Source-scoping conditions for confused-deputy protection and cross-account delivery.
+  # Priority: org ID (broadest, single condition) > account list > none (same-account only).
+  use_org_condition     = length(var.flow_logs_source_org_id) > 0
+  use_account_condition = !local.use_org_condition && length(var.flow_logs_source_account_ids) > 0
 }
 
 module "bucket_name" {
@@ -94,10 +108,17 @@ data "aws_iam_policy_document" "kms" {
   }
 }
 
-# https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs-s3.html
+# https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs-s3-permissions.html
 data "aws_iam_policy_document" "bucket" {
   count = module.this.enabled ? 1 : 0
 
+  # Grant the VPC Flow Logs delivery service permission to write log objects.
+  #
+  # The s3:x-amz-acl condition is only included when ACLs are enabled on the bucket
+  # (i.e. s3_object_ownership is ObjectWriter or BucketOwnerPreferred).  When
+  # BucketOwnerEnforced is in effect, S3 rejects all ACL-related headers; the
+  # delivery service sends no ACL header in that mode, so a StringEquals condition
+  # on s3:x-amz-acl would never match and would silently deny every write.
   statement {
     sid = "AWSLogDeliveryWrite"
 
@@ -114,16 +135,53 @@ data "aws_iam_policy_document" "bucket" {
       "${local.arn_format}:s3:::${local.bucket_name}/*"
     ]
 
-    condition {
-      test     = "StringEquals"
-      variable = "s3:x-amz-acl"
+    # Only add the ACL condition when ownership mode allows ACLs.
+    dynamic "condition" {
+      for_each = local.acl_condition_required ? [1] : []
+      content {
+        test     = "StringEquals"
+        variable = "s3:x-amz-acl"
+        values   = ["bucket-owner-full-control"]
+      }
+    }
 
-      values = [
-        "bucket-owner-full-control"
-      ]
+    # Scope to a specific AWS Organization (takes priority over per-account scoping).
+    dynamic "condition" {
+      for_each = local.use_org_condition ? [1] : []
+      content {
+        test     = "StringEquals"
+        variable = "aws:SourceOrgID"
+        values   = [var.flow_logs_source_org_id]
+      }
+    }
+
+    # Scope to explicit account IDs when no org ID is provided.
+    dynamic "condition" {
+      for_each = local.use_account_condition ? [1] : []
+      content {
+        test     = "StringEquals"
+        variable = "aws:SourceAccount"
+        values   = var.flow_logs_source_account_ids
+      }
+    }
+
+    # Restrict to ARNs originating from the listed accounts (confused-deputy protection).
+    dynamic "condition" {
+      for_each = local.use_account_condition ? [1] : []
+      content {
+        test     = "ArnLike"
+        variable = "aws:SourceArn"
+        values = [
+          for id in var.flow_logs_source_account_ids :
+          "${local.arn_format}:logs:*:${id}:*"
+        ]
+      }
     }
   }
 
+  # Grant the delivery service permission to read the bucket ACL so it can confirm
+  # the bucket-owner-full-control ACL requirement (still needed even for
+  # BucketOwnerEnforced buckets — AWS calls GetBucketAcl before writing).
   statement {
     sid = "AWSLogDeliveryAclCheck"
 
@@ -139,6 +197,37 @@ data "aws_iam_policy_document" "bucket" {
     resources = [
       "${local.arn_format}:s3:::${local.bucket_name}"
     ]
+
+    # Mirror the same source conditions applied to the Write statement.
+    dynamic "condition" {
+      for_each = local.use_org_condition ? [1] : []
+      content {
+        test     = "StringEquals"
+        variable = "aws:SourceOrgID"
+        values   = [var.flow_logs_source_org_id]
+      }
+    }
+
+    dynamic "condition" {
+      for_each = local.use_account_condition ? [1] : []
+      content {
+        test     = "StringEquals"
+        variable = "aws:SourceAccount"
+        values   = var.flow_logs_source_account_ids
+      }
+    }
+
+    dynamic "condition" {
+      for_each = local.use_account_condition ? [1] : []
+      content {
+        test     = "ArnLike"
+        variable = "aws:SourceArn"
+        values = [
+          for id in var.flow_logs_source_account_ids :
+          "${local.arn_format}:logs:*:${id}:*"
+        ]
+      }
+    }
   }
 
   dynamic "statement" {
@@ -213,7 +302,7 @@ module "s3_log_storage_bucket" {
   force_destroy = var.force_destroy
 
   acl                     = var.acl
-  s3_object_ownership     = var.s3_object_ownership == null ? "BucketOwnerEnforced" : var.s3_object_ownership
+  s3_object_ownership     = local.effective_ownership
   source_policy_documents = data.aws_iam_policy_document.bucket.*.json
 
   bucket_notifications_enabled = var.bucket_notifications_enabled

--- a/main.tf
+++ b/main.tf
@@ -105,6 +105,24 @@ data "aws_iam_policy_document" "kms" {
         "delivery.logs.amazonaws.com"
       ]
     }
+
+    # Mirror the same source scoping used on the bucket policy for confused-deputy protection.
+    dynamic "condition" {
+      for_each = local.use_org_condition ? [1] : []
+      content {
+        test     = "StringEquals"
+        variable = "aws:SourceOrgID"
+        values   = [var.flow_logs_source_org_id]
+      }
+    }
+    dynamic "condition" {
+      for_each = local.use_account_condition ? [1] : []
+      content {
+        test     = "StringEquals"
+        variable = "aws:SourceAccount"
+        values   = var.flow_logs_source_account_ids
+      }
+    }
   }
 }
 
@@ -179,9 +197,9 @@ data "aws_iam_policy_document" "bucket" {
     }
   }
 
-  # Grant the delivery service permission to read the bucket ACL so it can confirm
-  # the bucket-owner-full-control ACL requirement (still needed even for
-  # BucketOwnerEnforced buckets — AWS calls GetBucketAcl before writing).
+  # Grant the delivery service permission to read the bucket ACL. The log-delivery service calls
+  # GetBucketAcl as part of its pre-write checks regardless of Object Ownership mode; this is a
+  # bucket-policy read and is unrelated to ACL enforcement.
   statement {
     sid = "AWSLogDeliveryAclCheck"
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -39,12 +39,12 @@ output "bucket_prefix" {
 }
 
 output "flow_log_id" {
-  value       = join("", aws_flow_log.default.*.id)
+  value       = join("", aws_flow_log.default[*].id)
   description = "Flow Log ID"
 }
 
 output "flow_log_arn" {
-  value       = join("", aws_flow_log.default.*.arn)
+  value       = join("", aws_flow_log.default[*].arn)
   description = "Flow Log ARN"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -221,3 +221,33 @@ variable "log_format" {
   type        = string
   default     = null
 }
+
+variable "flow_logs_source_account_ids" {
+  type        = list(string)
+  description = <<-EOT
+    List of AWS account IDs that are authorized to deliver VPC Flow Logs to this bucket.
+    When set, adds `aws:SourceAccount` and `aws:SourceArn` conditions to the bucket delivery policy
+    statements, preventing confused-deputy attacks and enabling cross-account log delivery.
+    Multiple accounts may be listed (e.g., all spoke accounts in a landing zone).
+    When both `flow_logs_source_account_ids` and `flow_logs_source_org_id` are empty (the default),
+    no source conditions are added and the policy permits delivery from any account — this preserves
+    backward compatibility for single-account deployments.
+    EOT
+  default     = []
+  nullable    = false
+}
+
+variable "flow_logs_source_org_id" {
+  type        = string
+  description = <<-EOT
+    AWS Organizations ID (e.g. `o-xxxxxxxxxx`) whose member accounts are authorized to deliver
+    VPC Flow Logs to this bucket. When set, adds an `aws:SourceOrgID` condition to the bucket
+    delivery policy statements. This is the simplest way to authorize all accounts in an
+    organization without listing each account individually.
+    Takes precedence over `flow_logs_source_account_ids` when both are set.
+    When empty (the default), no source condition is added — backward-compatible for
+    single-account deployments.
+    EOT
+  default     = ""
+  nullable    = false
+}


### PR DESCRIPTION
## what

- Drop the `s3:x-amz-acl` condition from `AWSLogDeliveryWrite` when `s3_object_ownership = BucketOwnerEnforced` (ACLs disabled). When ACLs are disabled the delivery service sends no ACL header, so a `StringEquals s3:x-amz-acl` condition never matches, silently denying every write. The condition is now a `dynamic` block emitted only for ACL-enabled ownership modes (`ObjectWriter`, `BucketOwnerPreferred`).
- Add two optional variables for cross-account / org-wide delivery scoping with confused-deputy protection:
  - `flow_logs_source_org_id` — adds `aws:SourceOrgID` condition (authorize all accounts in an AWS Org)
  - `flow_logs_source_account_ids` — adds `aws:SourceAccount` + `aws:SourceArn` conditions (explicit account list)
  Both conditions are applied to `AWSLogDeliveryWrite` and `AWSLogDeliveryAclCheck`.
- Extract the repeated `var.s3_object_ownership == null ? "BucketOwnerEnforced" : var.s3_object_ownership` expression into a shared `local.effective_ownership` used by both the policy logic and the sub-module call.
- Update `README.yaml` with a multi-account usage example and document the ACL-condition behavior.

## why

### Bug 1 — silent delivery denial with BucketOwnerEnforced (the default)

`BucketOwnerEnforced` is both the AWS-recommended ownership setting and the value the module selects when `s3_object_ownership = null`. With ACLs disabled, S3 rejects any request that includes ACL-related headers. The log-delivery service therefore sends **no** ACL header. The existing `StringEquals s3:x-amz-acl = bucket-owner-full-control` condition then **never evaluates to true**, causing every `PutObject` to be denied.

This is the primary reason VPC Flow Logs fail with:
```
Access Denied for LogDestination: <bucket>. Please check LogDestination permission
```

### Bug 2 — cross-account delivery always fails

The original policy grants `delivery.logs.amazonaws.com` unconditionally for the `s3:PutObject` action. But AWS's cross-account delivery model **requires** explicit source-account or source-org authorization for the service principal to deliver on behalf of another account. Without it, attempting to create flow logs in a spoke account pointing at a bucket in a Log Archive account results in Access Denied. The new variables provide this scoping.

AWS reference (Nov 2023+): `aws:SourceOrgID` is supported for log delivery service principals, making org-wide authorization a single-line addition.

### Policy correctness reference

https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs-s3-permissions.html — the AWS-recommended policy for `BucketOwnerEnforced` buckets omits the `s3:x-amz-acl` condition entirely.

## backward compatibility

All new variables default to empty/null. When neither `flow_logs_source_org_id` nor `flow_logs_source_account_ids` is set, no source conditions are added — the policy shape is **identical to the previous behavior** for existing single-account callers.

The `s3:x-amz-acl` condition is preserved (via `dynamic` block) for callers using `BucketOwnerPreferred` or `ObjectWriter`, so ACL-enabled configurations are not changed.

## references

- https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs-s3-permissions.html
- https://aws.amazon.com/about-aws/whats-new/2023/11/vpc-flow-logs-aws-sourceorgid-condition-key/